### PR TITLE
Create empty Explorer settings key if missing.

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -37,6 +37,10 @@ if ($(Get-WindowsEdition -Online).Edition -notmatch "cor") {
     Set-ItemProperty "HKCU:\Control Panel\Accessibility\ToggleKeys" "Flags" "58"
 }
 
+if(!(Test-Path -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced")) {
+    New-Item -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" -Name "Advanced"
+}
+
 # Setting view options
 Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "Hidden" 1
 Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "HideFileExt" 0


### PR DESCRIPTION
Without this `setup.ps1` bails out when trying to set up the Explorer settings.